### PR TITLE
Add Tollbridge cdn reference

### DIFF
--- a/views/frontend/js-payload.php
+++ b/views/frontend/js-payload.php
@@ -7,7 +7,7 @@ global $post;
 
 if ( $manager->allAccountSettingsAreEntered() ) {
     ?>
-    <script type="text/javascript" src="https://<?php echo $manager->getAppId(); ?>/js/tollbridge.js"></script>
+    <script type="text/javascript" src="https://cdn.tollbridge.co/tollbridge.min.js"></script>
     <tollbridge-config
         app-id="<?php echo $manager->getAppId(); ?>"
         client-id="<?php echo $manager->getClientId(); ?>"


### PR DESCRIPTION
This addition allows the WordPress plugin to add a Tollbridge web component JS file using a CDN instead of loading it from Tollbridge like before.

DEPENDENT PR
[https://bitbucket.org/square1/tollbridge-paywall-web-component/pull-requests/46](https://bitbucket.org/square1/tollbridge-paywall-web-component/pull-requests/46)